### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -2,6 +2,9 @@
 # See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-multi-platform.yml
 name: CMake on a single platform
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/DQIX/BattleEmulator/security/code-scanning/1](https://github.com/DQIX/BattleEmulator/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block limiting the `GITHUB_TOKEN` to the least privileges required. This workflow only checks out the repository and uploads build artifacts; it does not need to write to repository contents, issues, or pull requests. The `actions/checkout` action needs `contents: read`, and `actions/upload-artifact` does not require additional repo scopes. Therefore, setting `permissions: contents: read` at the workflow root is sufficient and will apply to all jobs unless overridden.

Concretely, in `.github/workflows/cmake-single-platform.yml`, add a top‑level `permissions` section right after the `name:` (line 3) and before the `on:` block (line 5). The block should be:

```yaml
permissions:
  contents: read
```

No imports or additional methods are needed; this is purely a YAML configuration change within the existing workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
